### PR TITLE
use find(arr, fn) for node 0.12.x and older

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var EventEmitter = require('events');
 var inherits = require('util').inherits;
 var minimist = require('minimist');
 var each = require('each-series');
+var find = require('array-find');
 
 
 /**
@@ -70,7 +71,7 @@ Sushi.prototype.on = function (name) {
  */
 
 Sushi.prototype._findIndexCommand = function () {
-  return this.commands.find(function (command) {
+  return find(this.commands, function (command) {
     return command.name === 'index';
   });
 };

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Express for CLI apps",
   "main": "index.js",
   "dependencies": {
+    "array-find": "^1.0.0",
     "each-series": "^1.0.0",
     "minimist": "^1.2.0"
   },


### PR DESCRIPTION
Hey cool library!

This PR fixes the index route for node 0.12.x and older users
